### PR TITLE
Fix error when reading with "de2" locale

### DIFF
--- a/src/aviz.pro
+++ b/src/aviz.pro
@@ -2,6 +2,7 @@ TEMPLATE        = app
 TARGET          = aviz
 CONFIG          += qt opengl warn_on release thread
 QMAKE_CXXFLAGS  = -O2
+QMAKE_CXXFLAGS += -std=c++11  # for qt4
 QT +=  opengl 
 LIBS += -lX11 -lpng -lGLU
 

--- a/src/aviz.pro
+++ b/src/aviz.pro
@@ -2,9 +2,20 @@ TEMPLATE        = app
 TARGET          = aviz
 CONFIG          += qt opengl warn_on release thread
 QMAKE_CXXFLAGS  = -O2
-QMAKE_CXXFLAGS += -std=c++11  # for qt4
 QT +=  opengl 
 LIBS += -lX11 -lpng -lGLU
+
+# use C++11
+greaterThan(QT_MAJOR_VERSION, 4) {
+        # in qt5 there is a flag
+	CONFIG += c++11
+} else {
+    linux-g++ | linux-g++-32 | linux-g++-64 {
+    	QMAKE_CXXFLAGS += -std=c++0x 
+        #  newer version of g++ (GCC >4.7) use
+    	# QMAKE_CXXFLAGS += -std=c++11
+    }
+}
 
 message(testing for git descibe)
 system(git describe):HAS_GIT=TRUE

--- a/src/aviz.pro
+++ b/src/aviz.pro
@@ -71,7 +71,8 @@ HEADERS		= SoAnyThumbWheel.h \
 		  translationBoard.h \
 		  typeColorNumberBox.h \
 		  version.h \
-		  widgets/doneapplycancelwidget.h
+		  widgets/doneapplycancelwidget.h \
+                  exceptions.h
 SOURCES         = SoAnyThumbWheel.cpp \
 		  SoQtThumbWheel.cpp \
 		  animationBoard.cpp \

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -1,0 +1,15 @@
+#ifndef EXCEPTIONS_H
+#define EXCEPTIONS_H
+
+#include <stdexcept>
+
+namespace aviz {
+
+/* file parsing error */
+class parse_error : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+}
+
+#endif // EXCEPTIONS_H

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -5,9 +5,16 @@
 
 namespace aviz {
 
-/* file parsing error */
+/*! file parsing error */
 class parse_error : public std::runtime_error {
-    using std::runtime_error::runtime_error;
+
+public:
+     explicit parse_error (const std::string& what_arg)
+         :std::runtime_error(what_arg) {
+     }
+     explicit parse_error (const char* what_arg)
+         :std::runtime_error(what_arg) {
+     }
 };
 
 }

--- a/src/fileFunctions.cpp
+++ b/src/fileFunctions.cpp
@@ -76,8 +76,6 @@ bool fileExists( const char * filename )
     return exists;
 }
 
-namespace {
-
 particle parseParticleLine(const QString& line) {
     particle p;
     QStringList list = line.split(' ', QString::SkipEmptyParts);
@@ -118,7 +116,6 @@ particle parseParticleLine(const QString& line) {
                 values[9],
                 values[10]};
     return p;
-}
 }
 
 

--- a/src/fileFunctions.cpp
+++ b/src/fileFunctions.cpp
@@ -82,6 +82,8 @@ bool openCoordinateFunction( const char * filename, aggregateData * ad )
     float thisRead[11];
     char * buffer = (char*)malloc(BUFSIZ);
 
+    setlocale(LC_ALL,"C");
+
     // Open the file
     if (FILE * in = fopen( (char *)filename, "r" )) {
         // Register the filename

--- a/src/fileFunctions.cpp
+++ b/src/fileFunctions.cpp
@@ -33,6 +33,7 @@ Contact address: Computational Physics Group, Dept. of Physics,
 #include <iostream>
 #include <cstring>
 #include <exception>
+#include <stdexcept>
 
 #include <QString>
 #include <QStringList>

--- a/src/fileFunctions.cpp
+++ b/src/fileFunctions.cpp
@@ -23,22 +23,21 @@ Contact address: Computational Physics Group, Dept. of Physics,
                  Technion. 32000 Haifa Israel
                  gery@tx.technion.ac.il
 ***********************************************************************/
-
-#include "fileFunctions.h"
-#include "memoryFunctions.h"
-#include "version.h"
-#include "defaultParticles.h"
-
 #include <sys/stat.h>
 #include <iostream>
 #include <cstring>
-#include <exception>
-#include <stdexcept>
 
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
 #include <QFile>
+
+#include "fileFunctions.h"
+#include "memoryFunctions.h"
+#include "version.h"
+#include "defaultParticles.h"
+#include "version.h"
+#include "exceptions.h"
 
 // Check the suffix in a file name
 void checkSuffix( const char * filename, const char * suffix )
@@ -81,13 +80,13 @@ particle parseParticleLine(const QString& line) {
     particle p;
     QStringList list = line.split(' ', QString::SkipEmptyParts);
     if (list.count() < 4 || list.count() > 12) {
-        throw std::runtime_error ("Incorrect number of values. Expecting type, x, y, z and 8 or less properties");
+        throw aviz::parse_error("Incorrect number of values. Expecting type, x, y, z and 8 or less properties");
     }
 
     // Get the atom type
     QString type = list[0];
     if(type.length()!=2) {
-        throw std::runtime_error ("Incorrect format of type");
+        throw aviz::parse_error ("Incorrect format of type");
     }
 
     tag pTag;
@@ -100,7 +99,7 @@ particle parseParticleLine(const QString& line) {
         values[index-1] = QString(list[index]).toDouble(&ok);
         if(!ok) {
             QString msg = QString("Problem reading coordinate or property (%1:'%2')").arg(index).arg(list[index]);
-            throw std::runtime_error (qPrintable(msg));
+            throw aviz::parse_error (qPrintable(msg));
         }
     }
 
@@ -155,7 +154,7 @@ bool openCoordinateFunction(const char * filename, aggregateData * ad ){
                 try {
                     (*ad).particles[i] = parseParticleLine(line);
                 }
-                catch (std::runtime_error &e) {
+                catch (const aviz::parse_error &e) {
                     std::cout << "Problem reading line #" << i << ": " << e.what() << std::endl;
                     return false;
                 }

--- a/src/fileFunctions.cpp
+++ b/src/fileFunctions.cpp
@@ -30,11 +30,14 @@ Contact address: Computational Physics Group, Dept. of Physics,
 #include "defaultParticles.h"
 
 #include <sys/stat.h>
+#include <iostream>
 #include <cstring>
-#include <cstdlib>
+#include <exception>
 
 #include <QString>
 #include <QStringList>
+#include <QTextStream>
+#include <QFile>
 
 // Check the suffix in a file name
 void checkSuffix( const char * filename, const char * suffix )
@@ -73,28 +76,72 @@ bool fileExists( const char * filename )
     return exists;
 }
 
+namespace {
 
-// Read a coordinate file in XYZ format.  There can be up to 
-// eight additional property columns per line
-bool openCoordinateFunction( const char * filename, aggregateData * ad )
-{
-    char type[3];
-    float thisRead[11];
-    char * buffer = (char*)malloc(BUFSIZ);
+particle parseParticleLine(const QString& line) {
+    particle p;
+    QStringList list = line.split(' ', QString::SkipEmptyParts);
+    if (list.count() < 4 || list.count() > 12) {
+        throw std::runtime_error ("Incorrect number of values. Expecting type, x, y, z and 8 or less properties");
+    }
 
-    setlocale(LC_ALL,"C");
+    // Get the atom type
+    QString type = list[0];
+    if(type.length()!=2) {
+        throw std::runtime_error ("Incorrect format of type");
+    }
 
-    // Open the file
-    if (FILE * in = fopen( (char *)filename, "r" )) {
+    tag pTag;
+    pTag.type[0] = type.at(0).toLatin1();
+    pTag.type[1] = type.at(1).toLatin1();
+
+    float values[11] = {};
+    bool ok = true;
+    for(int index = 1; index < list.count(); index++) {
+        values[index-1] = QString(list[index]).toDouble(&ok);
+        if(!ok) {
+            QString msg = QString("Problem reading coordinate or property (%1:'%2')").arg(index).arg(list[index]);
+            throw std::runtime_error (qPrintable(msg));
+        }
+    }
+
+    return particle {pTag,
+                values[0], // x
+                values[1], // y
+                values[2], // z
+                values[3], // prop1
+                values[4], // prop2 ..
+                values[5],
+                values[6],
+                values[7],
+                values[8],
+                values[9],
+                values[10]};
+    return p;
+}
+}
+
+
+bool openCoordinateFunction(const char * filename, aggregateData * ad ){
+
+    QFile file(filename);
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+
         // Register the filename
         sprintf( (*ad).filename, "%s", filename );
 
+        QTextStream in(&file);
+
         // Read the number of particles
-        fgets( buffer, BUFSIZ, in );
-        (*ad).numberOfParticles = atoi(buffer);
+        bool ok = true;
+        (*ad).numberOfParticles = QString(in.readLine()).toInt(&ok);
+
+        if(!ok && in.atEnd()) {
+            return false;
+        }
 
         // Read the ID string
-        fgets( (*ad).IDstring, BUFSIZ, in );
+        std::strncpy((*ad).IDstring, in.readLine().toLatin1().constData(), BUFSIZ);
 
         // Free particle data memory
         freeAggregateData( ad );
@@ -104,73 +151,32 @@ bool openCoordinateFunction( const char * filename, aggregateData * ad )
 
         // Read the atom positions and properties
         int i = 0;
-        while (!feof(in)) {
-
-            fgets( buffer, BUFSIZ, in );
-
+        while (!in.atEnd()) {
+            QString line = in.readLine();
             if (i < (*ad).numberOfParticles) {
-
-                // Replace all tabs by a blank
-                int k = 0;
-                while (buffer[k] != 0) {
-                    if (buffer[k] == '\t')
-                        buffer[k] = ' ';
-                    k++;
+                try {
+                    (*ad).particles[i] = parseParticleLine(line);
                 }
-                // Get the atom type
-                k = 0;
-                while (buffer[k] == ' ') k++;
-                type[0] = buffer[0+k]; buffer[0+k] = ' ';
-                type[1] = buffer[1+k]; buffer[1+k] = ' ';
-                type[2] = 0;
-
-                // Read the rest
-                thisRead[0] = atof( strtok(buffer+2, " ") );
-
-                for (int j=1;j<11;j++) {
-                    char * ptr = strtok(NULL, " ");
-                    if (ptr) {
-                        thisRead[j] = atof( ptr );
-                    }
-                    else {
-                        thisRead[j] = 0.0;
-                    }
+                catch (std::runtime_error &e) {
+                    std::cout << "Problem reading line #" << i << ": " << e.what() << std::endl;
+                    return false;
                 }
-
-                sprintf( (char *)&(*ad).particles[i].type, "%s", type );
-                (*ad).particles[i].x = thisRead[0];
-                (*ad).particles[i].y = thisRead[1];
-                (*ad).particles[i].z = thisRead[2];
-                (*ad).particles[i].prop1 = thisRead[3];
-                (*ad).particles[i].prop2 = thisRead[4];
-                (*ad).particles[i].prop3 = thisRead[5];
-                (*ad).particles[i].prop4 = thisRead[6];
-                (*ad).particles[i].prop5 = thisRead[7];
-                (*ad).particles[i].prop6 = thisRead[8];
-                (*ad).particles[i].prop7 = thisRead[9];
-                (*ad).particles[i].prop8 = thisRead[10];
-                i++;
             }
+            i++;
         }
 
-        fclose( in );
-        free(buffer);
+        file.close();
 
         if (i != (*ad).numberOfParticles) {
             printf("The coordinate file is corrupted (number of lines mismatch) -- reading failed.\n");
             return false;
         }
-        else {
-            return true;
-        }
-    }
-    else {
-        free(buffer);
 
+        return true;
+    } else {
         return false;
     }
 }
-
 
 // Read a file list
 bool openFileListFunction( const char * filename, fileList * fl )

--- a/src/fileFunctions.h
+++ b/src/fileFunctions.h
@@ -29,6 +29,8 @@ Contact address: Computational Physics Group, Dept. of Physics,
 
 #include "data.h"
 
+class QString;
+
 void checkSuffix( const char *, const char * );
 bool fileExists( const char *);
 
@@ -60,5 +62,11 @@ bool openParticleDataFunction( const char *filename, particleData * );
  *  @return true if saved, false if file could not be opened
 */
 bool saveParticleDataFunction( const char *filename, particleData * );
+
+/*! Parse line of xzy file
+ * @return particle contained in that line
+ */
+particle parseParticleLine(const QString& line);
+
 
 #endif // FILE_H

--- a/src/fileFunctions.h
+++ b/src/fileFunctions.h
@@ -31,8 +31,14 @@ Contact address: Computational Physics Group, Dept. of Physics,
 
 void checkSuffix( const char *, const char * );
 bool fileExists( const char *);
+
+/*! Read a coordinate file in XYZ format.
+ * There can be up to eight additional property columns per line
+ */
 bool openCoordinateFunction( const char *filename, aggregateData * );
+
 bool openFileListFunction( const char *filename, fileList * );
+
 bool generateTrackDataFunction(const fileList&, aggregateData *, trackData * );
 
 /*! Save view parameters to file

--- a/src/fileFunctions.h
+++ b/src/fileFunctions.h
@@ -35,7 +35,9 @@ void checkSuffix( const char *, const char * );
 bool fileExists( const char *);
 
 /*! Read a coordinate file in XYZ format.
+ *
  * There can be up to eight additional property columns per line
+ *
  */
 bool openCoordinateFunction( const char *filename, aggregateData * );
 
@@ -44,27 +46,33 @@ bool openFileListFunction( const char *filename, fileList * );
 bool generateTrackDataFunction(const fileList&, aggregateData *, trackData * );
 
 /*! Save view parameters to file
- *  @return true if saved, false if file could not be opened
+ *  \return true if saved, false if file could not be opened
  */
 bool saveViewParamFunction( const char *filename, viewParam * );
 
 /*! Load view parameters from file
- *  @return true if saved, false if file could not be opened or incorrect version
+ *  \return true if saved, false if file could not be opened or incorrect version
  */
 bool openViewParamFunction( const char *filename, viewParam * );
 
 /*! Load particle data function (i.e. if and how to color what kind of particle) from file
- *  @return true if saved, false if file could not be opened or incorrect version
+ *  \return true if saved, false if file could not be opened or incorrect version
  */
 bool openParticleDataFunction( const char *filename, particleData * );
 
 /*! Save particle data function (i.e. if and how to color what kind of particle) to file
- *  @return true if saved, false if file could not be opened
+ *  \return true if saved, false if file could not be opened
 */
 bool saveParticleDataFunction( const char *filename, particleData * );
 
 /*! Parse line of xzy file
- * @return particle contained in that line
+ *
+ * Line consists of type, coordinates (x,y,z) and there can be up to eight additional
+ * property columns per line.
+ *
+ * \throws aviz::parse_error
+ * \sa openCoordinateFunction
+ * \return particle contained in that line
  */
 particle parseParticleLine(const QString& line);
 

--- a/src/glCanvasArea.cpp
+++ b/src/glCanvasArea.cpp
@@ -762,7 +762,7 @@ void GLCanvasArea::paintGL()
         // Set common material properties -- here shininess and
         // specular intensity are coupled
         GLfloat thisShininess[] = { vp.shininess };
-        GLfloat thisSpecular[] = {  (GLfloat)(vp.shininess)/128.0,  (GLfloat)(vp.shininess)/128.0,  (GLfloat)(vp.shininess)/128.0, 1.0 };
+        GLfloat thisSpecular[] = {  (GLfloat)(vp.shininess)/128.0f,  (GLfloat)(vp.shininess)/128.0f,  (GLfloat)(vp.shininess)/128.0f, 1.0f };
         glMaterialfv( GL_FRONT, GL_SHININESS, thisShininess );
         glMaterialfv( GL_FRONT, GL_SPECULAR, thisSpecular );
         glMaterialfv( GL_FRONT, GL_EMISSION, black_mat );

--- a/src/tests/fileFunctionsTest.cpp
+++ b/src/tests/fileFunctionsTest.cpp
@@ -1,0 +1,62 @@
+#include "../fileFunctions.h"
+
+#include <QtTest/QtTest>
+#include <QString>
+
+#include <exception>
+
+#if QT_VERSION < 0x050300
+// Our test system uses Qt5.2 but QVERIFY_EXCEPTION_THROWN first appears in Qt5.3
+    #include "verify_exception.h"
+#endif
+
+class TestFileFunctions: public QObject
+{
+    Q_OBJECT
+private slots:
+    void parseParticleLineSimple() {
+      auto p = parseParticleLine("X0 1.030e+04 1.040e+03 1.030e+04");
+
+      QCOMPARE(p.x, 1.030e+04);
+      QCOMPARE(p.y, 1.040e+03);
+      QCOMPARE(p.z, 1.030e+04);
+    }
+
+    void parseParticleLineSimpleTrailingSpace() {
+      auto p = parseParticleLine("X0 1.030e+04 1.040e+03 1.030e+04  ");
+
+      QCOMPARE(p.x, 1.030e+04);
+      QCOMPARE(p.y, 1.040e+03);
+      QCOMPARE(p.z, 1.030e+04);
+    }
+
+    void parseParticleLineWithParameters() {
+        auto p = parseParticleLine("X0 1.030e+04 1.040e+03 1.030e+04 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0");
+        QCOMPARE(p.x, 1.030e+04);
+        QCOMPARE(p.y, 1.040e+03);
+        QCOMPARE(p.z, 1.030e+04);
+        QCOMPARE(p.prop1, 1.0);
+        QCOMPARE(p.prop2, 2.0);
+        QCOMPARE(p.prop3, 3.0);
+        QCOMPARE(p.prop4, 4.0);
+        QCOMPARE(p.prop5, 5.0);
+        QCOMPARE(p.prop6, 6.0);
+        QCOMPARE(p.prop7, 7.0);
+        QCOMPARE(p.prop8, 8.0);
+    }
+
+    void parseParticleLineWrongType() {
+        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X011 1.030e+04 1.040e+03 1.030e+04"), std::runtime_error);
+    }
+
+    void parseParticleLineTooManyParameters() {
+        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X0 1.030e+04 1.040e+03 1.030e+04 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0"), std::runtime_error);
+    }
+
+    void parseParticleLineMissingZ() {
+        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X0 1.030e+04 1.040e+03"), std::runtime_error);
+    }
+};
+
+QTEST_MAIN(TestFileFunctions)
+#include "fileFunctionsTest.moc"

--- a/src/tests/fileFunctionsTest.cpp
+++ b/src/tests/fileFunctionsTest.cpp
@@ -3,7 +3,7 @@
 #include <QtTest/QtTest>
 #include <QString>
 
-#include <exception>
+#include "../exceptions.h"
 
 #if QT_VERSION < 0x050300
 // Our test system uses Qt5.2 but QVERIFY_EXCEPTION_THROWN first appears in Qt5.3
@@ -46,15 +46,15 @@ private slots:
     }
 
     void parseParticleLineWrongType() {
-        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X011 1.030e+04 1.040e+03 1.030e+04"), std::runtime_error);
+        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X011 1.030e+04 1.040e+03 1.030e+04"), aviz::parse_error);
     }
 
     void parseParticleLineTooManyParameters() {
-        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X0 1.030e+04 1.040e+03 1.030e+04 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0"), std::runtime_error);
+        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X0 1.030e+04 1.040e+03 1.030e+04 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0"), aviz::parse_error);
     }
 
     void parseParticleLineMissingZ() {
-        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X0 1.030e+04 1.040e+03"), std::runtime_error);
+        QVERIFY_EXCEPTION_THROWN(parseParticleLine("X0 1.030e+04 1.040e+03"), aviz::parse_error);
     }
 };
 

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -10,6 +10,7 @@ HEADERS = ../fileFunctions.h \
           ../memoryFunctions.h \
           ../version.h \
           ../defaultParticles.h \
+          ../exceptions.h \
           verify_exception.h
 SOURCES = fileFunctionsTest.cpp \
           ../fileFunctions.cpp \

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -1,0 +1,18 @@
+QT += testlib
+TEMPLATE = app
+TARGET = tests
+INCLUDEPATH += .
+QMAKE_CXXFLAGS += -std=c++11
+
+HEADERS = ../fileFunctions.h \
+          ../data.h \
+          ../defaults.h \
+          ../memoryFunctions.h \
+          ../version.h \
+          ../defaultParticles.h \
+          verify_exception.h
+SOURCES = fileFunctionsTest.cpp \
+          ../fileFunctions.cpp \
+          ../memoryFunctions.cpp \
+          ../defaultParticles.cpp \
+          ../version.cpp 

--- a/src/tests/verify_exception.h
+++ b/src/tests/verify_exception.h
@@ -1,0 +1,56 @@
+// The file contains code copied from https://github.com/qtproject/qtbase/blob/df757a2e62456a919dfe2e983f003123c3eb151c/src/testlib/qtestcase.h
+
+/****************************************************************************
+**
+** Copyright (C) 2015 The Qt Company Ltd.
+** Contact: http://www.qt.io/licensing/
+**
+** This file is part of the QtTest module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL21$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+# define QVERIFY_EXCEPTION_THROWN(expression, exceptiontype) \
+    do {\
+        QT_TRY {\
+            QT_TRY {\
+                expression;\
+             QTest::qFail("Expected exception of type " #exceptiontype " to be thrown" \
+             " but no exception caught", __FILE__, __LINE__);\
+             return;\
+            } QT_CATCH (const exceptiontype &) {\
+        }\
+    } QT_CATCH (const std::exception &e) {\
+        QByteArray msg = QByteArray() + "Expected exception of type " #exceptiontype \
+        " to be thrown but std::exception caught with message: " + e.what(); \
+        QTest::qFail(msg.constData(), __FILE__, __LINE__);\
+        return;\
+    } QT_CATCH (...) {\
+        QTest::qFail("Expected exception of type " #exceptiontype " to be thrown" \
+        " but unknown exception caught", __FILE__, __LINE__);\
+        return;\
+    }\
+    } while (0)


### PR DESCRIPTION
This fixes #33 

- Reworks parsing of data file
  - no longer use `atof`
  - throw exceptions which are caught to provide user additional information of why reading the file failed 
- Add testing